### PR TITLE
Add the actualcompressorspeed value

### DIFF
--- a/waterfurnace/waterfurnace.py
+++ b/waterfurnace/waterfurnace.py
@@ -232,6 +232,9 @@ class WFReading(object):
 
         # fan speed (0 - 10)
         self.airflowcurrentspeed = data.get('airflowcurrentspeed')
+        
+        # compressor speed
+        self.actualcompressorspeed = data.get('actualcompressorspeed')
 
         # humidity (%)
         self.tstatdehumidsetpoint = data.get('tstatdehumidsetpoint')


### PR DESCRIPTION
Make the actualcompressorspeed value available for use by the home-assistant Waterfurnace component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/waterfurnace/2)
<!-- Reviewable:end -->
