### PR TITLE
Remove dependencies on pytest-runner and mock

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -79,7 +79,7 @@ Ready to contribute? Here's how to set up `waterfurnace` for local development.
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
     $ flake8 waterfurnace tests
-    $ python setup.py test or py.test
+    $ py.test
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,3 @@ coverage==4.1
 Sphinx==1.4.8
 PyYAML>=3.11
 pytest==2.9.2
-mock

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,5 +7,4 @@ coverage==4.1
 Sphinx==1.4.8
 PyYAML>=3.11
 pytest==2.9.2
-pytest-runner==2.11.1
 mock

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup_requirements = [
 
 test_requirements = [
     'pytest',
-    'mock'
     # TODO: put package test requirements here
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ requirements = [
 ]
 
 setup_requirements = [
-    'pytest-runner',
     # TODO(sdague): put setup requirements (distutils extensions, etc.) here
 ]
 
@@ -64,7 +63,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
-    test_suite='tests',
-    tests_require=test_requirements,
     setup_requires=setup_requirements,
+    extras_require={
+        "test": test_requirements,
+    },
 )

--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -3,7 +3,7 @@
 """Tests for `waterfurnace` package."""
 
 import json
-import mock
+from unittest import mock
 import unittest
 
 import pytest

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -3,7 +3,7 @@
 """Tests for `waterfurnace` package."""
 import logging
 import json
-import mock
+from unittest import mock
 import unittest
 import time
 


### PR DESCRIPTION
First, this removes `pytest-runner` from `setup_requires`, and removes `test_suite` and `test_requires`, which are deprecated and only useful with `setup.py test`.

The `pytest-runner` package has been deprecated upstream for some time, and the project is now archived:
https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice

Furthermore, the "setup.py test" command was removed in setuptools 72: https://github.com/pypa/setuptools/blob/v75.8.0/NEWS.rst#v7200

This does not affect running the tests with `pytest` or `tox`.

----

Additionally, this removes the dependency on the [PyPI `mock` package](https://pypi.org/project/mock/), using [`unittest.mock`](https://docs.python.org/3.13/library/unittest.mock.html) from the standard library (available since Python 3.3) instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/waterfurnace/12)
<!-- Reviewable:end -->
