### PR TITLE
Allow click to prompt for password if not provided in CLI

### DIFF
--- a/waterfurnace/cli.py
+++ b/waterfurnace/cli.py
@@ -16,7 +16,16 @@ logger.setLevel(logging.INFO)
 
 @click.command()
 @click.option("-u", "--username", "user", required=True, help="Symphony username")
-@click.option("-p", "--password", "passwd", required=True, help="Symphony password")
+@click.option(
+    "-p",
+    "--password",
+    "passwd",
+    envvar="WF_PASSWORD",
+    prompt=True,
+    hide_input=True,
+    confirmation_prompt=False,
+    help="Symphony password (or set WF_PASSWORD env var)",
+)
 @click.option(
     "-s",
     "--sensors",


### PR DESCRIPTION
Add support for the CLI to automatically prompt for a password if one isn't provided, or use an env variable (`WF_PASSWORD`) if it exists. This is done to prevent the password from showing up in the shell history.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/waterfurnace/13)
<!-- Reviewable:end -->
