### PR TITLE
Add support for fetching energy information for units

### DIFF
--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -224,3 +224,195 @@ class TestReadData(unittest.TestCase):
         mock_ws_create.return_value = m_ws
         with pytest.raises(wf.WFWebsocketClosedError):
             w.read()
+
+
+class TestEnergyData(unittest.TestCase):
+
+    def test_energy_reading_hourly_data(self):
+        """Test WFEnergyReading with hourly/15min frequency data."""
+        columns = [
+            "total_heat_1", "total_heat_2", "total_cool_1", "total_cool_2",
+            "total_electric_heat", "total_fan_only", "total_loop_pump",
+            "total_dehumidification", "runtime_heat_1", "runtime_heat_2",
+            "runtime_cool_1", "runtime_cool_2", "runtime_electric_heat",
+            "runtime_fan_only", "runtime_dehumidification", "total_records",
+            "cool_runtime", "heat_runtime", "total_power"
+        ]
+        values = [0.46, 0.0, 0, 0, 0.0, 0.0, 0, 0, 0.47, 0.0, 0, 0, 0.0, 0.0, 0, 168, 0, 0.47, 0.46]
+        timestamp_ms = 1767578400000
+
+        reading = wf.WFEnergyReading(timestamp_ms, values, columns)
+
+        assert reading.timestamp_ms == timestamp_ms
+        assert reading.total_heat_1 == 0.46
+        assert reading.total_heat_2 == 0.0
+        assert reading.total_power == 0.46
+        assert reading.heat_runtime == 0.47
+        assert reading.cool_runtime == 0
+        assert reading.get("total_heat_1") == 0.46
+        assert reading.get("nonexistent", "default") == "default"
+
+    def test_energy_reading_daily_data(self):
+        """Test WFEnergyReading with daily frequency data."""
+        columns = [
+            "id", "cool_runtime", "defrost_runtime", "dehumidification_runtime",
+            "heat_runtime", "time_zone", "total_cool_1", "total_cool_2",
+            "total_dehumidification", "total_electric_heat", "total_fan_only",
+            "total_heat_1", "total_heat_2", "total_power", "total_records"
+        ]
+        values = [
+            "6CC840023E88", 0, 0, 0, 23.98, "America/New_York",
+            0, 0, 0, 0.0, 0.0, 17.32, 2.71, 20.03, 8641
+        ]
+        timestamp_ms = 1767434400000
+
+        reading = wf.WFEnergyReading(timestamp_ms, values, columns)
+
+        assert reading.id == "6CC840023E88"
+        assert reading.time_zone == "America/New_York"
+        assert reading.heat_runtime == 23.98
+        assert reading.total_power == 20.03
+        assert reading.defrost_runtime == 0
+        assert reading.dehumidification_runtime == 0
+
+    def test_energy_data_container(self):
+        """Test WFEnergyData container with multiple readings."""
+        fake_energy_response = {
+            "columns": ["total_heat_1", "total_heat_2", "total_power", "heat_runtime"],
+            "index": [1767578400000, 1767574800000, 1767571200000],
+            "data": [
+                [0.46, 0.0, 0.46, 0.47],
+                [0.98, 0.0, 0.98, 1.0],
+                [1.01, 0.0, 1.01, 1.0]
+            ]
+        }
+
+        energy_data = wf.WFEnergyData(fake_energy_response)
+
+        assert len(energy_data) == 3
+        assert len(energy_data.readings) == 3
+        assert energy_data.columns == fake_energy_response["columns"]
+
+        # Test iteration
+        count = 0
+        for reading in energy_data:
+            assert isinstance(reading, wf.WFEnergyReading)
+            count += 1
+        assert count == 3
+
+        # Test indexing
+        first_reading = energy_data[0]
+        assert first_reading.total_heat_1 == 0.46
+        assert first_reading.total_power == 0.46
+
+        second_reading = energy_data[1]
+        assert second_reading.total_heat_1 == 0.98
+        assert second_reading.total_power == 0.98
+
+    def test_energy_data_empty(self):
+        """Test WFEnergyData with empty data."""
+        empty_response = {
+            "columns": [],
+            "index": [],
+            "data": []
+        }
+
+        energy_data = wf.WFEnergyData(empty_response)
+        assert len(energy_data) == 0
+        assert len(energy_data.readings) == 0
+
+    @mock.patch("requests.get")
+    @mock.patch("websocket.create_connection")
+    @mock.patch("requests.post")
+    def test_get_energy_data_success(self, mock_post, mock_ws_create, mock_get):
+        """Test successful get_energy_data call."""
+        # Setup login mocks
+        mock_post.return_value = FakeRequest(
+            cookies={"sessionid": "test_session_id"}
+        )
+        m_ws = mock.MagicMock()
+        m_ws.recv.return_value = FAKE_CONTENT
+        mock_ws_create.return_value = m_ws
+
+        # Setup energy data response
+        fake_energy_response = {
+            "columns": ["total_heat_1", "total_power", "heat_runtime"],
+            "index": [1767578400000, 1767574800000],
+            "data": [[0.46, 0.46, 0.47], [0.98, 0.98, 1.0]]
+        }
+
+        mock_response = mock.MagicMock()
+        mock_response.json.return_value = fake_energy_response
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_get.return_value = mock_response
+
+        # Create instance and login
+        w = wf.WaterFurnace("test@example.com", "password")
+        w.login()
+
+        # Get energy data
+        energy_data = w.get_energy_data("2026-01-03", "2026-01-04", "1H", "America/New_York")
+
+        # Verify the request was made correctly
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        assert "freq=1H" in call_args[0][0]
+        assert "start=2026-01-03" in call_args[0][0]
+        assert "end=2026-01-04" in call_args[0][0]
+        assert "timezone=America/New_York" in call_args[0][0]
+        assert call_args[1]["cookies"]["sessionid"] == "test_session_id"
+
+        # Verify the returned data
+        assert isinstance(energy_data, wf.WFEnergyData)
+        assert len(energy_data) == 2
+
+    def test_get_energy_data_not_logged_in(self):
+        """Test get_energy_data raises error when not logged in."""
+        w = wf.WaterFurnace("test@example.com", "password")
+
+        with pytest.raises(wf.WFCredentialError):
+            w.get_energy_data("2026-01-03", "2026-01-04")
+
+    @mock.patch("websocket.create_connection")
+    @mock.patch("requests.post")
+    def test_get_energy_data_invalid_frequency(self, mock_post, mock_ws_create):
+        """Test get_energy_data raises error with invalid frequency."""
+        # Setup login mocks
+        mock_post.return_value = FakeRequest(
+            cookies={"sessionid": "test_session_id"}
+        )
+        m_ws = mock.MagicMock()
+        m_ws.recv.return_value = FAKE_CONTENT
+        mock_ws_create.return_value = m_ws
+
+        w = wf.WaterFurnace("test@example.com", "password")
+        w.login()
+
+        with pytest.raises(ValueError):
+            w.get_energy_data("2026-01-03", "2026-01-04", frequency="invalid")
+
+    @mock.patch("requests.get")
+    @mock.patch("websocket.create_connection")
+    @mock.patch("requests.post")
+    def test_get_energy_data_http_error(self, mock_post, mock_ws_create, mock_get):
+        """Test get_energy_data handles HTTP errors."""
+        import requests
+
+        # Setup login mocks
+        mock_post.return_value = FakeRequest(
+            cookies={"sessionid": "test_session_id"}
+        )
+        m_ws = mock.MagicMock()
+        m_ws.recv.return_value = FAKE_CONTENT
+        mock_ws_create.return_value = m_ws
+
+        # Setup error response
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("HTTP Error")
+        mock_get.return_value = mock_response
+
+        w = wf.WaterFurnace("test@example.com", "password")
+        w.login()
+
+        with pytest.raises(wf.WFError):
+            w.get_energy_data("2026-01-03", "2026-01-04")

--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -68,7 +68,9 @@ class TestSymphony(unittest.TestCase):
         m_ws.recv.return_value = FAKE_CONTENT
         mock_ws_create.return_value = m_ws
 
-        w = wf.WaterFurnace(str(mock.sentinel.email), str(mock.sentinel.passwd))
+        w = wf.WaterFurnace(
+            str(mock.sentinel.email), str(mock.sentinel.passwd)
+        )
         w.login()
         assert m_ws.method_calls[0] == mock.call.send(
             json.dumps(
@@ -238,7 +240,10 @@ class TestEnergyData(unittest.TestCase):
             "runtime_fan_only", "runtime_dehumidification", "total_records",
             "cool_runtime", "heat_runtime", "total_power"
         ]
-        values = [0.46, 0.0, 0, 0, 0.0, 0.0, 0, 0, 0.47, 0.0, 0, 0, 0.0, 0.0, 0, 168, 0, 0.47, 0.46]
+        values = [
+            0.46, 0.0, 0, 0, 0.0, 0.0, 0, 0, 0.47,
+            0.0, 0, 0, 0.0, 0.0, 0, 168, 0, 0.47, 0.46
+        ]
         timestamp_ms = 1767578400000
 
         reading = wf.WFEnergyReading(timestamp_ms, values, columns)
@@ -255,10 +260,12 @@ class TestEnergyData(unittest.TestCase):
     def test_energy_reading_daily_data(self):
         """Test WFEnergyReading with daily frequency data."""
         columns = [
-            "id", "cool_runtime", "defrost_runtime", "dehumidification_runtime",
-            "heat_runtime", "time_zone", "total_cool_1", "total_cool_2",
-            "total_dehumidification", "total_electric_heat", "total_fan_only",
-            "total_heat_1", "total_heat_2", "total_power", "total_records"
+            "id", "cool_runtime", "defrost_runtime",
+            "dehumidification_runtime", "heat_runtime",
+            "time_zone", "total_cool_1", "total_cool_2",
+            "total_dehumidification", "total_electric_heat",
+            "total_fan_only", "total_heat_1", "total_heat_2",
+            "total_power", "total_records"
         ]
         values = [
             "6CC840023E88", 0, 0, 0, 23.98, "America/New_York",
@@ -278,7 +285,12 @@ class TestEnergyData(unittest.TestCase):
     def test_energy_data_container(self):
         """Test WFEnergyData container with multiple readings."""
         fake_energy_response = {
-            "columns": ["total_heat_1", "total_heat_2", "total_power", "heat_runtime"],
+            "columns": [
+                "total_heat_1",
+                "total_heat_2",
+                "total_power",
+                "heat_runtime"
+            ],
             "index": [1767578400000, 1767574800000, 1767571200000],
             "data": [
                 [0.46, 0.0, 0.46, 0.47],
@@ -324,7 +336,9 @@ class TestEnergyData(unittest.TestCase):
     @mock.patch("requests.get")
     @mock.patch("websocket.create_connection")
     @mock.patch("requests.post")
-    def test_get_energy_data_success(self, mock_post, mock_ws_create, mock_get):
+    def test_get_energy_data_success(
+        self, mock_post, mock_ws_create, mock_get
+    ):
         """Test successful get_energy_data call."""
         # Setup login mocks
         mock_post.return_value = FakeRequest(
@@ -351,7 +365,9 @@ class TestEnergyData(unittest.TestCase):
         w.login()
 
         # Get energy data
-        energy_data = w.get_energy_data("2026-01-03", "2026-01-04", "1H", "America/New_York")
+        energy_data = w.get_energy_data(
+            "2026-01-03", "2026-01-04", "1H", "America/New_York"
+        )
 
         # Verify the request was made correctly
         mock_get.assert_called_once()
@@ -375,7 +391,9 @@ class TestEnergyData(unittest.TestCase):
 
     @mock.patch("websocket.create_connection")
     @mock.patch("requests.post")
-    def test_get_energy_data_invalid_frequency(self, mock_post, mock_ws_create):
+    def test_get_energy_data_invalid_frequency(
+        self, mock_post, mock_ws_create
+    ):
         """Test get_energy_data raises error with invalid frequency."""
         # Setup login mocks
         mock_post.return_value = FakeRequest(
@@ -394,7 +412,9 @@ class TestEnergyData(unittest.TestCase):
     @mock.patch("requests.get")
     @mock.patch("websocket.create_connection")
     @mock.patch("requests.post")
-    def test_get_energy_data_http_error(self, mock_post, mock_ws_create, mock_get):
+    def test_get_energy_data_http_error(
+        self, mock_post, mock_ws_create, mock_get
+    ):
         """Test get_energy_data handles HTTP errors."""
         import requests
 
@@ -408,7 +428,9 @@ class TestEnergyData(unittest.TestCase):
 
         # Setup error response
         mock_response = mock.MagicMock()
-        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("HTTP Error")
+        mock_response.raise_for_status.side_effect = (
+            requests.exceptions.HTTPError("HTTP Error")
+        )
         mock_get.return_value = mock_response
 
         w = wf.WaterFurnace("test@example.com", "password")

--- a/waterfurnace/cli.py
+++ b/waterfurnace/cli.py
@@ -15,7 +15,13 @@ logger.setLevel(logging.INFO)
 
 
 @click.command()
-@click.option("-u", "--username", "user", required=True, help="Symphony username")
+@click.option(
+    "-u",
+    "--username",
+    "user",
+    required=True,
+    help="Symphony username"
+)
 @click.option(
     "-p",
     "--password",
@@ -106,7 +112,10 @@ logger.setLevel(logging.INFO)
     show_default=True,
     help="Timezone for energy data",
 )
-def main(user, passwd, sensors, continuous, device, location, vendor, debug, energy, start_date, end_date, frequency, timezone_str):
+def main(
+    user, passwd, sensors, continuous, device, location, vendor, debug,
+    energy, start_date, end_date, frequency, timezone_str
+):
 
     click.echo("\nStep 1: Login")
     if debug:
@@ -127,7 +136,9 @@ def main(user, passwd, sensors, continuous, device, location, vendor, debug, ene
     if energy:
         # Energy data mode
         if not start_date or not end_date:
-            click.echo("Error: --start and --end dates are required for energy data")
+            click.echo(
+                "Error: --start and --end dates are required for energy data"
+            )
             return
 
         click.echo("\nStep 2: Get Energy Data")
@@ -136,8 +147,12 @@ def main(user, passwd, sensors, continuous, device, location, vendor, debug, ene
         ))
 
         try:
-            energy_data = wf.get_energy_data(start_date, end_date, frequency, timezone_str)
-            click.echo("\nReceived {} energy readings".format(len(energy_data)))
+            energy_data = wf.get_energy_data(
+                start_date, end_date, frequency, timezone_str
+            )
+            click.echo(
+                "\nReceived {} energy readings".format(len(energy_data))
+            )
 
             if len(energy_data) == 0:
                 click.echo("No data available for the specified time range")
@@ -152,7 +167,12 @@ def main(user, passwd, sensors, continuous, device, location, vendor, debug, ene
                 if not filtered:
                     return None, None, None, None
                 total = sum(filtered)
-                return min(filtered), max(filtered), total / len(filtered), total
+                return (
+                    min(filtered),
+                    max(filtered),
+                    total / len(filtered),
+                    total
+                )
 
             # Collect values for each metric
             metrics = {
@@ -161,7 +181,9 @@ def main(user, passwd, sensors, continuous, device, location, vendor, debug, ene
                 "Total Heat 2": [r.total_heat_2 for r in energy_data],
                 "Total Cool 1": [r.total_cool_1 for r in energy_data],
                 "Total Cool 2": [r.total_cool_2 for r in energy_data],
-                "Total Electric Heat": [r.total_electric_heat for r in energy_data],
+                "Total Electric Heat": [
+                    r.total_electric_heat for r in energy_data
+                ],
                 "Total Fan Only": [r.total_fan_only for r in energy_data],
                 "Total Loop Pump": [r.total_loop_pump for r in energy_data],
                 "Heat Runtime": [r.heat_runtime for r in energy_data],

--- a/waterfurnace/cli.py
+++ b/waterfurnace/cli.py
@@ -70,7 +70,43 @@ logger.setLevel(logging.INFO)
     help="Select vendor",
 )
 @click.option("-d", "--debug", "debug", required=False, is_flag=True)
-def main(user, passwd, sensors, continuous, device, location, vendor, debug):
+@click.option(
+    "-e",
+    "--energy",
+    "energy",
+    required=False,
+    is_flag=True,
+    help="Get energy data instead of sensor readings",
+)
+@click.option(
+    "--start",
+    "start_date",
+    required=False,
+    help="Start date for energy data (YYYY-MM-DD)",
+)
+@click.option(
+    "--end",
+    "end_date",
+    required=False,
+    help="End date for energy data (YYYY-MM-DD)",
+)
+@click.option(
+    "--freq",
+    "frequency",
+    required=False,
+    default="1H",
+    show_default=True,
+    help="Energy data frequency: 1D (daily), 1H (hourly), 15min (15 minutes)",
+)
+@click.option(
+    "--timezone",
+    "timezone_str",
+    required=False,
+    default="America/New_York",
+    show_default=True,
+    help="Timezone for energy data",
+)
+def main(user, passwd, sensors, continuous, device, location, vendor, debug, energy, start_date, end_date, frequency, timezone_str):
 
     click.echo("\nStep 1: Login")
     if debug:
@@ -88,34 +124,94 @@ def main(user, passwd, sensors, continuous, device, location, vendor, debug):
 
     click.echo("Login Succeeded: session_id = {}".format(wf.sessionid))
 
-    while True:
+    if energy:
+        # Energy data mode
+        if not start_date or not end_date:
+            click.echo("Error: --start and --end dates are required for energy data")
+            return
 
-        dt = datetime.datetime.now()
-        now = dt.strftime("%Y-%m-%d %H:%M:%S")
+        click.echo("\nStep 2: Get Energy Data")
+        click.echo("Start: {}, End: {}, Frequency: {}, Timezone: {}".format(
+            start_date, end_date, frequency, timezone_str
+        ))
 
-        click.echo("")
-        click.echo("Attempting to read data {}".format(now))
-        data = wf.read()
+        try:
+            energy_data = wf.get_energy_data(start_date, end_date, frequency, timezone_str)
+            click.echo("\nReceived {} energy readings".format(len(energy_data)))
 
-        if sensors is None:
-            click.echo(data)
-        else:
-            if sensors == "all":
-                attrs = dir(data)
-                sensorlist = []
-                for attr in attrs:
-                    if not attr.startswith("_"):
-                        sensorlist.append(attr)
+            if len(energy_data) == 0:
+                click.echo("No data available for the specified time range")
+                return
+
+            # Calculate summary statistics for key metrics
+            click.echo("\nEnergy Data Summary:")
+
+            # Helper function to calculate stats
+            def calc_stats(values):
+                filtered = [v for v in values if v is not None]
+                if not filtered:
+                    return None, None, None, None
+                total = sum(filtered)
+                return min(filtered), max(filtered), total / len(filtered), total
+
+            # Collect values for each metric
+            metrics = {
+                "Total Power": [r.total_power for r in energy_data],
+                "Total Heat 1": [r.total_heat_1 for r in energy_data],
+                "Total Heat 2": [r.total_heat_2 for r in energy_data],
+                "Total Cool 1": [r.total_cool_1 for r in energy_data],
+                "Total Cool 2": [r.total_cool_2 for r in energy_data],
+                "Total Electric Heat": [r.total_electric_heat for r in energy_data],
+                "Total Fan Only": [r.total_fan_only for r in energy_data],
+                "Total Loop Pump": [r.total_loop_pump for r in energy_data],
+                "Heat Runtime": [r.heat_runtime for r in energy_data],
+                "Cool Runtime": [r.cool_runtime for r in energy_data],
+            }
+
+            # Display statistics for each metric
+            for metric_name, values in metrics.items():
+                min_val, max_val, avg_val, total_val = calc_stats(values)
+                if min_val is not None:
+                    click.echo("\n{}:".format(metric_name))
+                    click.echo("   Min: {:.2f}".format(min_val))
+                    click.echo("   Max: {:.2f}".format(max_val))
+                    click.echo("   Avg: {:.2f}".format(avg_val))
+                    click.echo("   Total: {:.2f}".format(total_val))
+
+        except Exception as e:
+            click.echo("Error getting energy data: {}".format(e))
+            raise
+
+    else:
+        # Normal sensor reading mode
+        while True:
+
+            dt = datetime.datetime.now()
+            now = dt.strftime("%Y-%m-%d %H:%M:%S")
+
+            click.echo("")
+            click.echo("Attempting to read data {}".format(now))
+            data = wf.read()
+
+            if sensors is None:
+                click.echo(data)
             else:
-                sensorlist = list(sensors.split(","))
+                if sensors == "all":
+                    attrs = dir(data)
+                    sensorlist = []
+                    for attr in attrs:
+                        if not attr.startswith("_"):
+                            sensorlist.append(attr)
+                else:
+                    sensorlist = list(sensors.split(","))
 
-            for sensor in sensorlist:
-                click.echo("{} = {}".format(sensor, getattr(data, sensor)))
+                for sensor in sensorlist:
+                    click.echo("{} = {}".format(sensor, getattr(data, sensor)))
 
-        if continuous:
-            time.sleep(15)
-        else:
-            break
+            if continuous:
+                time.sleep(15)
+            else:
+                break
 
 
 if __name__ == "__main__":

--- a/waterfurnace/waterfurnace.py
+++ b/waterfurnace/waterfurnace.py
@@ -109,7 +109,8 @@ class WFError(WFException):
 
 class SymphonyGeothermal(object):
     def __init__(
-        self, base_url, login_url, ws_url, user, passwd, max_fails=5, device=0, location=0
+        self, base_url, login_url, ws_url, user, passwd,
+        max_fails=5, device=0, location=0
     ):
         self.base_url = base_url
         self.login_url = login_url
@@ -134,7 +135,8 @@ class SymphonyGeothermal(object):
 
     def _get_session_id(self):
         data = dict(
-            emailaddress=self.user, password=self.passwd, op="login", redirect="/"
+            emailaddress=self.user, password=self.passwd,
+            op="login", redirect="/"
         )
         headers = {
             "user-agent": USER_AGENT,
@@ -214,7 +216,9 @@ class SymphonyGeothermal(object):
                     break
 
             if not location:
-                raise WFError("Unable to find location: {}".format(self.location))
+                raise WFError(
+                    "Unable to find location: {}".format(self.location)
+                )
         else:
             raise WFError(
                 "Unknown location type ({}): {}. Should be int or str".format(
@@ -238,7 +242,10 @@ class SymphonyGeothermal(object):
             for index, gateway_data in enumerate(gateways):
                 gateway_gwid = gateway_data.get("gwid")
                 gateway_description = gateway_data.get("description")
-                if gateway_gwid == self.device or gateway_description == self.device:
+                if (
+                    gateway_gwid == self.device or
+                    gateway_description == self.device
+                ):
                     device = gateways[index]
                     break
 
@@ -319,15 +326,21 @@ class SymphonyGeothermal(object):
                 self.fails = self.fails + 1
                 _LOGGER.exception("websocket read failed, reconnecting")
                 time.sleep(self.fails * ERROR_INTERVAL)
-        raise WFWebsocketClosedError("Failed to refresh credentials after retries")
+        raise WFWebsocketClosedError(
+            "Failed to refresh credentials after retries"
+        )
 
-    def get_energy_data(self, start_date, end_date, frequency="1H", timezone_str="America/New_York"):
+    def get_energy_data(
+        self, start_date, end_date,
+        frequency="1H", timezone_str="America/New_York"
+    ):
         """Get energy data for a date range.
 
         Args:
             start_date: Start date as string in YYYY-MM-DD format
             end_date: End date as string in YYYY-MM-DD format
-            frequency: Data frequency - "1D" (daily), "1H" (hourly), or "15min" (15 minutes)
+            frequency: Data frequency - "1D" (daily),
+                       "1H" (hourly), or "15min" (15 minutes)
             timezone_str: Timezone string (e.g., "America/New_York")
 
         Returns:
@@ -343,12 +356,15 @@ class SymphonyGeothermal(object):
         # Validate frequency
         valid_frequencies = ["1D", "1H", "15min"]
         if frequency not in valid_frequencies:
-            raise ValueError(f"Invalid frequency. Must be one of {valid_frequencies}")
+            raise ValueError(
+                f"Invalid frequency. Must be one of {valid_frequencies}"
+            )
 
         # Build the API URL
         url = (
             f"{self.base_url}/api.php/v2/gateway/{self.gwid}/energy"
-            f"?freq={frequency}&start={start_date}&timezone={timezone_str}&end={end_date}"
+            f"?freq={frequency}&start={start_date}"
+            f"&timezone={timezone_str}&end={end_date}"
         )
 
         headers = {
@@ -371,7 +387,9 @@ class SymphonyGeothermal(object):
             )
             res.raise_for_status()
             data = res.json()
-            _LOGGER.debug(f"Received energy data: {len(data.get('index', []))} records")
+            _LOGGER.debug(
+                f"Received energy data: {len(data.get('index', []))} records"
+            )
             return WFEnergyData(data)
         except requests.exceptions.HTTPError as e:
             _LOGGER.error(f"HTTP error getting energy data: {e}")
@@ -387,14 +405,16 @@ class SymphonyGeothermal(object):
 class WaterFurnace(SymphonyGeothermal):
     def __init__(self, user, passwd, max_fails=5, device=0, location=0):
         super().__init__(
-            WF_BASE_URL, WF_LOGIN_URL, WF_WS_URL, user, passwd, max_fails, device, location
+            WF_BASE_URL, WF_LOGIN_URL, WF_WS_URL, user,
+            passwd, max_fails, device, location
         )
 
 
 class GeoStar(SymphonyGeothermal):
     def __init__(self, user, passwd, max_fails=5, device=0, location=0):
         super().__init__(
-            GS_BASE_URL, GS_LOGIN_URL, GS_WS_URL, user, passwd, max_fails, device, location
+            GS_BASE_URL, GS_LOGIN_URL, GS_WS_URL, user,
+            passwd, max_fails, device, location
         )
 
 
@@ -472,7 +492,9 @@ class WFEnergyReading(object):
         """
         self.timestamp_ms = timestamp_ms
         # Convert milliseconds to seconds for datetime
-        self.timestamp = datetime.fromtimestamp(timestamp_ms / 1000.0, tz=timezone.utc)
+        self.timestamp = datetime.fromtimestamp(
+            timestamp_ms / 1000.0, tz=timezone.utc
+        )
 
         # Create a mapping for easy access
         data_dict = {}
@@ -499,14 +521,18 @@ class WFEnergyReading(object):
         self.runtime_cool_2 = data_dict.get("runtime_cool_2")
         self.runtime_electric_heat = data_dict.get("runtime_electric_heat")
         self.runtime_fan_only = data_dict.get("runtime_fan_only")
-        self.runtime_dehumidification = data_dict.get("runtime_dehumidification")
+        self.runtime_dehumidification = data_dict.get(
+            "runtime_dehumidification"
+        )
         self.cool_runtime = data_dict.get("cool_runtime")
         self.heat_runtime = data_dict.get("heat_runtime")
 
         # Daily frequency specific fields
         self.id = data_dict.get("id")
         self.defrost_runtime = data_dict.get("defrost_runtime")
-        self.dehumidification_runtime = data_dict.get("dehumidification_runtime")
+        self.dehumidification_runtime = data_dict.get(
+            "dehumidification_runtime"
+        )
         self.time_zone = data_dict.get("time_zone")
 
         # Store all raw data for any custom access
@@ -525,7 +551,9 @@ class WFEnergyReading(object):
         return self._raw_data.get(key, default)
 
     def __repr__(self):
-        return f"<WFEnergyReading timestamp={self.timestamp}, power={self.total_power}>"
+        return f"<WFEnergyReading timestamp={self.timestamp}, power={
+            self.total_power
+        }>"
 
 
 class WFEnergyData(object):
@@ -545,7 +573,9 @@ class WFEnergyData(object):
         self.readings = []
         for i, timestamp in enumerate(self.index):
             if i < len(self.data):
-                reading = WFEnergyReading(timestamp, self.data[i], self.columns)
+                reading = WFEnergyReading(
+                    timestamp, self.data[i], self.columns
+                )
                 self.readings.append(reading)
 
     def __iter__(self):

--- a/waterfurnace/waterfurnace.py
+++ b/waterfurnace/waterfurnace.py
@@ -8,6 +8,7 @@ import logging
 import ssl
 import threading
 import time
+from datetime import datetime, timezone
 
 import requests
 import websocket
@@ -15,9 +16,11 @@ import websocket
 _LOGGER = logging.getLogger(__name__)
 
 USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:142.0) Gecko/20100101 Firefox/142.0"
-WF_LOGIN_URL = "https://symphony.mywaterfurnace.com/account/login"
+WF_BASE_URL = "https://symphony.mywaterfurnace.com"
+WF_LOGIN_URL = f"{WF_BASE_URL}/account/login"
 WF_WS_URL = "wss://awlclientproxy.mywaterfurnace.com/"
-GS_LOGIN_URL = "https://symphony.mygeostar.com/account/login"
+GS_BASE_URL = "https://symphony.mygeostar.com"
+GS_LOGIN_URL = f"{GS_BASE_URL}/account/login"
 GS_WS_URL = "wss://awlclientproxy.mygeostar.com/"
 
 FURNACE_MODE = (
@@ -106,8 +109,9 @@ class WFError(WFException):
 
 class SymphonyGeothermal(object):
     def __init__(
-        self, login_url, ws_url, user, passwd, max_fails=5, device=0, location=0
+        self, base_url, login_url, ws_url, user, passwd, max_fails=5, device=0, location=0
     ):
+        self.base_url = base_url
         self.login_url = login_url
         self.ws_url = ws_url
         self.user = user
@@ -317,18 +321,80 @@ class SymphonyGeothermal(object):
                 time.sleep(self.fails * ERROR_INTERVAL)
         raise WFWebsocketClosedError("Failed to refresh credentials after retries")
 
+    def get_energy_data(self, start_date, end_date, frequency="1H", timezone_str="America/New_York"):
+        """Get energy data for a date range.
+
+        Args:
+            start_date: Start date as string in YYYY-MM-DD format
+            end_date: End date as string in YYYY-MM-DD format
+            frequency: Data frequency - "1D" (daily), "1H" (hourly), or "15min" (15 minutes)
+            timezone_str: Timezone string (e.g., "America/New_York")
+
+        Returns:
+            WFEnergyData object containing energy readings
+
+        Raises:
+            WFCredentialError: If not logged in or session invalid
+            WFError: If API request fails
+        """
+        if not self.sessionid or not self.gwid:
+            raise WFCredentialError("Must login before getting energy data")
+
+        # Validate frequency
+        valid_frequencies = ["1D", "1H", "15min"]
+        if frequency not in valid_frequencies:
+            raise ValueError(f"Invalid frequency. Must be one of {valid_frequencies}")
+
+        # Build the API URL
+        url = (
+            f"{self.base_url}/api.php/v2/gateway/{self.gwid}/energy"
+            f"?freq={frequency}&start={start_date}&timezone={timezone_str}&end={end_date}"
+        )
+
+        headers = {
+            "user-agent": USER_AGENT,
+        }
+
+        cookies = {
+            "sessionid": self.sessionid,
+            "legal-acknowledge": "yes",
+        }
+
+        _LOGGER.debug(f"Requesting energy data from: {url}")
+
+        try:
+            res = requests.get(
+                url,
+                headers=headers,
+                cookies=cookies,
+                timeout=TIMEOUT,
+            )
+            res.raise_for_status()
+            data = res.json()
+            _LOGGER.debug(f"Received energy data: {len(data.get('index', []))} records")
+            return WFEnergyData(data)
+        except requests.exceptions.HTTPError as e:
+            _LOGGER.error(f"HTTP error getting energy data: {e}")
+            raise WFError(f"Failed to get energy data: {e}")
+        except requests.exceptions.RequestException as e:
+            _LOGGER.error(f"Request error getting energy data: {e}")
+            raise WFError(f"Failed to get energy data: {e}")
+        except (ValueError, KeyError) as e:
+            _LOGGER.error(f"Error parsing energy data response: {e}")
+            raise WFError(f"Invalid energy data response: {e}")
+
 
 class WaterFurnace(SymphonyGeothermal):
     def __init__(self, user, passwd, max_fails=5, device=0, location=0):
         super().__init__(
-            WF_LOGIN_URL, WF_WS_URL, user, passwd, max_fails, device, location
+            WF_BASE_URL, WF_LOGIN_URL, WF_WS_URL, user, passwd, max_fails, device, location
         )
 
 
 class GeoStar(SymphonyGeothermal):
     def __init__(self, user, passwd, max_fails=5, device=0, location=0):
         super().__init__(
-            GS_LOGIN_URL, GS_WS_URL, user, passwd, max_fails, device, location
+            GS_BASE_URL, GS_LOGIN_URL, GS_WS_URL, user, passwd, max_fails, device, location
         )
 
 
@@ -390,4 +456,112 @@ class WFReading(object):
                 self.tstatroomtemp,
                 self.tstatactivesetpoint,
             )
+        )
+
+
+class WFEnergyReading(object):
+    """Represents a single energy data reading for a specific time period."""
+
+    def __init__(self, timestamp_ms, values, columns):
+        """Initialize energy reading.
+
+        Args:
+            timestamp_ms: Unix timestamp in milliseconds
+            values: List of values corresponding to columns
+            columns: List of column names
+        """
+        self.timestamp_ms = timestamp_ms
+        # Convert milliseconds to seconds for datetime
+        self.timestamp = datetime.fromtimestamp(timestamp_ms / 1000.0, tz=timezone.utc)
+
+        # Create a mapping for easy access
+        data_dict = {}
+        for i, col in enumerate(columns):
+            if i < len(values):
+                data_dict[col] = values[i]
+
+        # Common fields for all frequencies
+        self.total_heat_1 = data_dict.get("total_heat_1")
+        self.total_heat_2 = data_dict.get("total_heat_2")
+        self.total_cool_1 = data_dict.get("total_cool_1")
+        self.total_cool_2 = data_dict.get("total_cool_2")
+        self.total_electric_heat = data_dict.get("total_electric_heat")
+        self.total_fan_only = data_dict.get("total_fan_only")
+        self.total_loop_pump = data_dict.get("total_loop_pump")
+        self.total_dehumidification = data_dict.get("total_dehumidification")
+        self.total_power = data_dict.get("total_power")
+        self.total_records = data_dict.get("total_records")
+
+        # Runtime fields (hour/15min frequency)
+        self.runtime_heat_1 = data_dict.get("runtime_heat_1")
+        self.runtime_heat_2 = data_dict.get("runtime_heat_2")
+        self.runtime_cool_1 = data_dict.get("runtime_cool_1")
+        self.runtime_cool_2 = data_dict.get("runtime_cool_2")
+        self.runtime_electric_heat = data_dict.get("runtime_electric_heat")
+        self.runtime_fan_only = data_dict.get("runtime_fan_only")
+        self.runtime_dehumidification = data_dict.get("runtime_dehumidification")
+        self.cool_runtime = data_dict.get("cool_runtime")
+        self.heat_runtime = data_dict.get("heat_runtime")
+
+        # Daily frequency specific fields
+        self.id = data_dict.get("id")
+        self.defrost_runtime = data_dict.get("defrost_runtime")
+        self.dehumidification_runtime = data_dict.get("dehumidification_runtime")
+        self.time_zone = data_dict.get("time_zone")
+
+        # Store all raw data for any custom access
+        self._raw_data = data_dict
+
+    def get(self, key, default=None):
+        """Get any field by column name.
+
+        Args:
+            key: Column name
+            default: Default value if key not found
+
+        Returns:
+            Value for the given column or default
+        """
+        return self._raw_data.get(key, default)
+
+    def __repr__(self):
+        return f"<WFEnergyReading timestamp={self.timestamp}, power={self.total_power}>"
+
+
+class WFEnergyData(object):
+    """Container for energy data with multiple readings."""
+
+    def __init__(self, data={}):
+        """Initialize energy data from API response.
+
+        Args:
+            data: Dictionary containing columns, index, and data arrays
+        """
+        self.columns = data.get("columns", [])
+        self.index = data.get("index", [])
+        self.data = data.get("data", [])
+
+        # Create reading objects for easier access
+        self.readings = []
+        for i, timestamp in enumerate(self.index):
+            if i < len(self.data):
+                reading = WFEnergyReading(timestamp, self.data[i], self.columns)
+                self.readings.append(reading)
+
+    def __iter__(self):
+        """Allow iteration over readings."""
+        return iter(self.readings)
+
+    def __len__(self):
+        """Return number of readings."""
+        return len(self.readings)
+
+    def __getitem__(self, index):
+        """Allow indexed access to readings."""
+        return self.readings[index]
+
+    def __repr__(self):
+        return (
+            f"<WFEnergyData records={len(self.readings)}, "
+            f"columns={len(self.columns)}>"
         )


### PR DESCRIPTION
This introduces a new `get_energy_data` method under `SymphonyGeothermal` for fetching historical energy information. It accepts a start and end date, as well as a frequency. This is limited only to 15 minutes, 1 hour, and 1 day intervals. While the API does expose weekly, and monthly data these require different parameters and I didn't think those were necessary to have.

This also introduces an option to fetch data via the CLI. This was mostly done for demonstration and testing purposes, but happy to omit it if it's not valuable.

The changes also include unit test coverage.

Disclaimer: Much of the code here was generated with the assistance of Claude Code. I have reviewed all code, edited where needed, and manually tested it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/waterfurnace/14)
<!-- Reviewable:end -->
