### PR TITLE
Expose device and location information to clients

### DIFF
--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -467,3 +467,129 @@ class TestEnergyData(unittest.TestCase):
 
         with pytest.raises(wf.WFError):
             w.get_energy_data("2026-01-03", "2026-01-04")
+
+
+class TestSymphonyLocationMethods:
+    """Tests for get_location, get_locations, and get_devices methods."""
+
+    def _create_symphony_instance(self, location=0, device=0):
+        """Helper to create a SymphonyGeothermal instance."""
+        return wf.SymphonyGeothermal(
+            "http://base.url",
+            "http://login.url",
+            "ws://ws.url",
+            "test@example.com",
+            "password",
+            device=device,
+            location=location,
+        )
+
+    def test_get_locations_before_login_raises_error(self):
+        """Test get_locations raises error if not logged in."""
+        symphony = self._create_symphony_instance()
+        with pytest.raises(
+            wf.WFCredentialError, match="Must login before getting locations"
+        ):
+            symphony.get_locations()
+
+    def test_get_locations_returns_list(self):
+        """Test get_locations returns a list of locations."""
+        symphony = self._create_symphony_instance()
+        loc_data = [
+            {
+                "description": "Home",
+                "gateways": [{"gwid": "gw-1"}],
+            },
+            {
+                "description": "Office",
+                "gateways": [{"gwid": "gw-2"}],
+            },
+        ]
+        symphony.locations = [wf.WFLocation(loc) for loc in loc_data]
+        locations = symphony.get_locations()
+        assert len(locations) == 2
+        assert all(isinstance(loc, wf.WFLocation) for loc in locations)
+
+    def test_get_location_before_login_raises_error(self):
+        """Test get_location raises error if not logged in."""
+        symphony = self._create_symphony_instance()
+        with pytest.raises(
+            wf.WFCredentialError, match="Must login before getting locations"
+        ):
+            symphony.get_location()
+
+    def test_get_location_by_index(self):
+        """Test get_location returns correct location by index."""
+        symphony = self._create_symphony_instance(location=0)
+        loc_data = [
+            {"description": "Home", "gateways": [{"gwid": "gw-1"}]},
+            {"description": "Office", "gateways": [{"gwid": "gw-2"}]},
+        ]
+        symphony.locations = [wf.WFLocation(loc) for loc in loc_data]
+        location = symphony.get_location()
+        assert location.description == "Home"
+
+    def test_get_location_index_out_of_range(self):
+        """Test get_location raises error for invalid index."""
+        symphony = self._create_symphony_instance(location=5)
+        loc_data = [{"description": "Home", "gateways": [{"gwid": "gw-1"}]}]
+        symphony.locations = [wf.WFLocation(loc) for loc in loc_data]
+        with pytest.raises(wf.WFError, match="Location index out of range"):
+            symphony.get_location()
+
+    def test_get_location_unknown_type(self):
+        """Test get_location raises error for invalid location type."""
+        symphony = self._create_symphony_instance(location="invalid_string")
+        loc_data = [{"description": "Home", "gateways": [{"gwid": "gw-1"}]}]
+        symphony.locations = [wf.WFLocation(loc) for loc in loc_data]
+        with pytest.raises(wf.WFError, match="Unknown location type"):
+            symphony.get_location()
+
+    def test_get_devices_before_login_raises_error(self):
+        """Test get_devices raises error if not logged in."""
+        symphony = self._create_symphony_instance()
+        with pytest.raises(
+            wf.WFCredentialError, match="Must login before getting devices"
+        ):
+            symphony.get_devices()
+
+    def test_get_devices_returns_list(self):
+        """Test get_devices returns a list of devices/gateways."""
+        symphony = self._create_symphony_instance(location=0)
+        loc_data = {
+            "description": "Home",
+            "gateways": [
+                {"gwid": "gw-1", "description": "Device 1"},
+                {"gwid": "gw-2", "description": "Device 2"},
+            ],
+        }
+        symphony.locations = [wf.WFLocation(loc_data)]
+        devices = symphony.get_devices()
+        assert len(devices) == 2
+        assert all(isinstance(dev, wf.WFGateway) for dev in devices)
+        assert devices[0].gwid == "gw-1"
+        assert devices[1].gwid == "gw-2"
+
+    def test_get_devices_no_devices(self):
+        """Test get_devices with location that has no devices."""
+        symphony = self._create_symphony_instance(location=0)
+        loc_data = {"description": "Home", "gateways": []}
+        symphony.locations = [wf.WFLocation(loc_data)]
+        devices = symphony.get_devices()
+        assert devices == []
+
+    def test_get_devices_location_index_out_of_range(self):
+        """Test get_devices raises error for invalid location index."""
+        symphony = self._create_symphony_instance(location=10)
+        loc_data = {"description": "Home", "gateways": [{"gwid": "gw-1"}]}
+        symphony.locations = [wf.WFLocation(loc_data)]
+        with pytest.raises(wf.WFError, match="Location index out of range"):
+            symphony.get_devices()
+
+    def test_get_devices_unknown_location_type(self):
+        """Test get_devices raises error for invalid location type."""
+        symphony = self._create_symphony_instance(location="invalid_string")
+        loc_data = {"description": "Home", "gateways": [{"gwid": "gw-1"}]}
+        symphony.locations = [wf.WFLocation(loc_data)]
+        with pytest.raises(wf.WFError, match="Unknown location type"):
+            symphony.get_devices()

--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -470,7 +470,7 @@ class TestEnergyData(unittest.TestCase):
 
 
 class TestSymphonyLocationMethods:
-    """Tests for get_location, get_locations, and get_devices methods."""
+    """Tests for locations and devices properties in SymphonyGeothermal."""
 
     def _create_symphony_instance(self, location=0, device=0):
         """Helper to create a SymphonyGeothermal instance."""
@@ -484,16 +484,13 @@ class TestSymphonyLocationMethods:
             location=location,
         )
 
-    def test_get_locations_before_login_raises_error(self):
-        """Test get_locations raises error if not logged in."""
+    def test_locations_before_login_is_none(self):
+        """Test location property is None if not logged in."""
         symphony = self._create_symphony_instance()
-        with pytest.raises(
-            wf.WFCredentialError, match="Must login before getting locations"
-        ):
-            symphony.get_locations()
+        assert symphony.locations is None
 
-    def test_get_locations_returns_list(self):
-        """Test get_locations returns a list of locations."""
+    def test_locations_returns_list(self):
+        """Test locations is a list of WFLocation objects."""
         symphony = self._create_symphony_instance()
         loc_data = [
             {
@@ -505,56 +502,18 @@ class TestSymphonyLocationMethods:
                 "gateways": [{"gwid": "gw-2"}],
             },
         ]
-        symphony.locations = [wf.WFLocation(loc) for loc in loc_data]
-        locations = symphony.get_locations()
-        assert len(locations) == 2
-        assert all(isinstance(loc, wf.WFLocation) for loc in locations)
+        symphony._location_data = loc_data
+        assert len(symphony.locations) == 2
+        assert all(isinstance(loc, wf.WFLocation) for loc in symphony.locations)
 
-    def test_get_location_before_login_raises_error(self):
-        """Test get_location raises error if not logged in."""
+    def test_devices_before_login_is_none(self):
+        """Test devices property is None if not logged in."""
         symphony = self._create_symphony_instance()
-        with pytest.raises(
-            wf.WFCredentialError, match="Must login before getting locations"
-        ):
-            symphony.get_location()
 
-    def test_get_location_by_index(self):
-        """Test get_location returns correct location by index."""
-        symphony = self._create_symphony_instance(location=0)
-        loc_data = [
-            {"description": "Home", "gateways": [{"gwid": "gw-1"}]},
-            {"description": "Office", "gateways": [{"gwid": "gw-2"}]},
-        ]
-        symphony.locations = [wf.WFLocation(loc) for loc in loc_data]
-        location = symphony.get_location()
-        assert location.description == "Home"
+        assert symphony.devices is None
 
-    def test_get_location_index_out_of_range(self):
-        """Test get_location raises error for invalid index."""
-        symphony = self._create_symphony_instance(location=5)
-        loc_data = [{"description": "Home", "gateways": [{"gwid": "gw-1"}]}]
-        symphony.locations = [wf.WFLocation(loc) for loc in loc_data]
-        with pytest.raises(wf.WFError, match="Location index out of range"):
-            symphony.get_location()
-
-    def test_get_location_unknown_type(self):
-        """Test get_location raises error for invalid location type."""
-        symphony = self._create_symphony_instance(location="invalid_string")
-        loc_data = [{"description": "Home", "gateways": [{"gwid": "gw-1"}]}]
-        symphony.locations = [wf.WFLocation(loc) for loc in loc_data]
-        with pytest.raises(wf.WFError, match="Unknown location type"):
-            symphony.get_location()
-
-    def test_get_devices_before_login_raises_error(self):
-        """Test get_devices raises error if not logged in."""
-        symphony = self._create_symphony_instance()
-        with pytest.raises(
-            wf.WFCredentialError, match="Must login before getting devices"
-        ):
-            symphony.get_devices()
-
-    def test_get_devices_returns_list(self):
-        """Test get_devices returns a list of devices/gateways."""
+    def test_devices_is_list(self):
+        """Test devices is a list of WFGateway objects."""
         symphony = self._create_symphony_instance(location=0)
         loc_data = {
             "description": "Home",
@@ -563,33 +522,18 @@ class TestSymphonyLocationMethods:
                 {"gwid": "gw-2", "description": "Device 2"},
             ],
         }
-        symphony.locations = [wf.WFLocation(loc_data)]
-        devices = symphony.get_devices()
+        symphony._location_data = [loc_data]
+        devices = symphony.devices
+
         assert len(devices) == 2
         assert all(isinstance(dev, wf.WFGateway) for dev in devices)
         assert devices[0].gwid == "gw-1"
         assert devices[1].gwid == "gw-2"
 
-    def test_get_devices_no_devices(self):
-        """Test get_devices with location that has no devices."""
+    def test_devices_no_devices_in_location(self):
+        """Test devices with location that has no devices."""
         symphony = self._create_symphony_instance(location=0)
         loc_data = {"description": "Home", "gateways": []}
-        symphony.locations = [wf.WFLocation(loc_data)]
-        devices = symphony.get_devices()
-        assert devices == []
+        symphony._location_data = [loc_data]
 
-    def test_get_devices_location_index_out_of_range(self):
-        """Test get_devices raises error for invalid location index."""
-        symphony = self._create_symphony_instance(location=10)
-        loc_data = {"description": "Home", "gateways": [{"gwid": "gw-1"}]}
-        symphony.locations = [wf.WFLocation(loc_data)]
-        with pytest.raises(wf.WFError, match="Location index out of range"):
-            symphony.get_devices()
-
-    def test_get_devices_unknown_location_type(self):
-        """Test get_devices raises error for invalid location type."""
-        symphony = self._create_symphony_instance(location="invalid_string")
-        loc_data = {"description": "Home", "gateways": [{"gwid": "gw-1"}]}
-        symphony.locations = [wf.WFLocation(loc_data)]
-        with pytest.raises(wf.WFError, match="Unknown location type"):
-            symphony.get_devices()
+        assert symphony.devices == []

--- a/waterfurnace/cli.py
+++ b/waterfurnace/cli.py
@@ -139,9 +139,7 @@ def main(
     click.echo("Login Succeeded: session_id = {}".format(wf.sessionid))
 
     click.echo("Selected Location: {}".format(wf.get_location().description))
-    click.echo("Selected Device: {}".format(
-        wf.get_devices()[device].description)
-    )
+    click.echo("Selected Device: {}".format(wf.get_devices()[device].description))
 
     if energy:
         # Energy data mode

--- a/waterfurnace/cli.py
+++ b/waterfurnace/cli.py
@@ -138,6 +138,11 @@ def main(
 
     click.echo("Login Succeeded: session_id = {}".format(wf.sessionid))
 
+    click.echo("Selected Location: {}".format(wf.get_location().description))
+    click.echo("Selected Device: {}".format(
+        wf.get_devices()[device].description)
+    )
+
     if energy:
         # Energy data mode
         if not start_date or not end_date:

--- a/waterfurnace/waterfurnace.py
+++ b/waterfurnace/waterfurnace.py
@@ -714,4 +714,6 @@ class WFLocation:
         self._raw = data
 
     def __repr__(self):
-        return f"<WFLocation description={self.description} gateways={len(self.gateways)}>"
+        return (
+            f"<WFLocation description={self.description} gateways={len(self.gateways)}>"
+        )

--- a/waterfurnace/waterfurnace.py
+++ b/waterfurnace/waterfurnace.py
@@ -261,7 +261,7 @@ class SymphonyGeothermal(object):
         else:
             raise WFError(
                 "Unknown device type ({}): {}. Should be int or str".format(
-                    type(self.location), self.location
+                    type(self.device), self.device
                 )
             )
 

--- a/waterfurnace/waterfurnace.py
+++ b/waterfurnace/waterfurnace.py
@@ -132,6 +132,7 @@ class SymphonyGeothermal(object):
         # For retry logic
         self.max_fails = max_fails
         self.fails = 0
+        self.locations = []
         _LOGGER.debug(self)
 
     def __repr__(self):
@@ -205,6 +206,11 @@ class SymphonyGeothermal(object):
         locations = data["locations"]
         location = None
 
+        if not locations:
+            raise WFError("Login succeeded but no locations found in account")
+
+        self.locations = [WFLocation(loc) for loc in locations]
+
         if isinstance(self.location, int):
             try:
                 location = locations[self.location]
@@ -267,6 +273,75 @@ class SymphonyGeothermal(object):
         # reset the transaction id if we start over
         self.tid = 1
         self._login_ws()
+
+    def get_locations(self):
+        """Get all available locations.
+
+        Returns:
+            List of WFLocation objects
+
+        Raises:
+            WFCredentialError: If not logged in
+        """
+        if not self.locations:
+            raise WFCredentialError("Must login before getting locations")
+        return self.locations
+
+    def get_location(self):
+        """Get the current location.
+
+        Returns:
+            WFLocation object
+
+        Raises:
+            WFCredentialError: If not logged in
+            WFError: If location not found
+        """
+        if not self.locations:
+            raise WFCredentialError("Must login before getting locations")
+
+        target_location = None
+        if isinstance(self.location, int):
+            try:
+                target_location = self.locations[self.location]
+            except IndexError:
+                raise WFError(
+                    f"Location index out of range. Max index is {
+                        len(self.locations) - 1
+                    }"
+                )
+        else:
+            raise WFError("Unknown location type")
+
+        return target_location
+
+    def get_devices(self):
+        """Get all devices for the current location.
+
+        Returns:
+            List of WFGateway objects
+
+        Raises:
+            WFCredentialError: If not logged in
+            WFError: If location not found
+        """
+        if not self.locations:
+            raise WFCredentialError("Must login before getting devices")
+
+        target_location = None
+        if isinstance(self.location, int):
+            try:
+                target_location = self.locations[self.location]
+            except IndexError:
+                raise WFError(
+                    f"Location index out of range. Max index is {
+                        len(self.locations) - 1
+                    }"
+                )
+        else:
+            raise WFError("Unknown location type")
+
+        return target_location.gateways
 
     def _abort(self, *args, **kwargs):
         _LOGGER.warning("Timeout on websocket request. Aborting websocket")
@@ -591,3 +666,58 @@ class WFEnergyData(object):
             f"<WFEnergyData records={len(self.readings)}, "
             f"columns={len(self.columns)}>"
         )
+
+
+class WFGateway:
+    """Represents a Symphony gateway/device."""
+
+    def __init__(self, data):
+        if "gwid" not in data:
+            raise ValueError("Gateway data must contain 'gwid' field")
+
+        self.gwid = data["gwid"]
+
+        self.description = data.get("description", self.gwid)
+        self.type = data.get("type")
+        self.awltstattype = data.get("awltstattype")
+        self.awltstattypedesc = data.get("awltstattypedesc")
+        self.iz2_max_zones = data.get("iz2_max_zones")
+        self.awlabctypedesc = data.get("awlabctypedesc")
+        self.awlabctype = data.get("awlabctype")
+        self.blowertype = data.get("blowertype")
+        self.online = data.get("online", 1)  # Assume online if not specified
+        self.tstat_name = data.get("tstat_name")
+
+        # Store raw data for debugging/future extensibility
+        self._raw = data
+
+    def is_online(self):
+        """Check if gateway is currently online."""
+        return bool(self.online)
+
+    def __repr__(self):
+        return f"<WFGateway gwid={self.gwid} description={self.description}>"
+
+
+class WFLocation:
+    """Represents a Symphony location."""
+
+    def __init__(self, data):
+        self.description = data.get("description", "Unknown")
+        self.postal = data.get("postal")
+        self.city = data.get("city")
+        self.state = data.get("state")
+        self.country = data.get("country")
+        self.latitude = data.get("latitude")
+        self.longitude = data.get("longitude")
+
+        # Convert gateways to WFGateway objects
+        self.gateways = [WFGateway(gw) for gw in data.get("gateways", [])]
+
+        # Store raw data for debugging/future extensibility
+        self._raw = data
+
+    def __repr__(self):
+        return f"<WFLocation description={self.description} gateways={
+            len(self.gateways)
+        }>"

--- a/waterfurnace/waterfurnace.py
+++ b/waterfurnace/waterfurnace.py
@@ -306,9 +306,7 @@ class SymphonyGeothermal(object):
                 target_location = self.locations[self.location]
             except IndexError:
                 raise WFError(
-                    f"Location index out of range. Max index is {
-                        len(self.locations) - 1
-                    }"
+                    f"Location index out of range. Max index is {len(self.locations) - 1}"
                 )
         else:
             raise WFError("Unknown location type")
@@ -334,9 +332,7 @@ class SymphonyGeothermal(object):
                 target_location = self.locations[self.location]
             except IndexError:
                 raise WFError(
-                    f"Location index out of range. Max index is {
-                        len(self.locations) - 1
-                    }"
+                    f"Location index out of range. Max index is {len(self.locations) - 1}"
                 )
         else:
             raise WFError("Unknown location type")

--- a/waterfurnace/waterfurnace.py
+++ b/waterfurnace/waterfurnace.py
@@ -714,6 +714,4 @@ class WFLocation:
         self._raw = data
 
     def __repr__(self):
-        return f"<WFLocation description={self.description} gateways={
-            len(self.gateways)
-        }>"
+        return f"<WFLocation description={self.description} gateways={len(self.gateways)}>"


### PR DESCRIPTION
Add `get_locations`, `get_location` and `get_devices` methods to `SymphonyGeothermal` so that clients can query for additional information about the current location, and available devices.

The goal is to use this to auto-discover all available devices on an account, for use in the Home Assistant setup flow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/waterfurnace/15)
<!-- Reviewable:end -->
