### PR TITLE
Store unique account id

### DIFF
--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -10,7 +10,11 @@ import pytest
 
 from waterfurnace import waterfurnace as wf
 
-FAKE_RESPONSE = {"err": "", "locations": [{"gateways": [{"gwid": "123456"}]}]}
+FAKE_RESPONSE = {
+    "err": "",
+    "key": 1234,
+    "locations": [{"gateways": [{"gwid": "123456"}]}],
+}
 
 
 FAKE_CONTENT = json.dumps(FAKE_RESPONSE)
@@ -81,6 +85,21 @@ class TestSymphony(unittest.TestCase):
             )
         )
         assert m_ws.method_calls[1] == mock.call.recv()
+
+    @mock.patch("websocket.create_connection")
+    @mock.patch("websocket.recv")
+    @mock.patch("requests.post")
+    def test_get_account_id(self, mock_req, m_recv, mock_ws_create):
+        mock_req.return_value = FakeRequest(
+            cookies={"sessionid": str(mock.sentinel.sessionid)},
+        )
+        m_ws = mock.MagicMock()
+        m_ws.recv.return_value = FAKE_CONTENT
+        mock_ws_create.return_value = m_ws
+
+        w = wf.WaterFurnace(str(mock.sentinel.email), str(mock.sentinel.passwd))
+        w.login()
+        assert w.account_id == 1234
 
     @mock.patch("websocket.create_connection")
     @mock.patch("requests.post")

--- a/waterfurnace/waterfurnace.py
+++ b/waterfurnace/waterfurnace.py
@@ -133,6 +133,8 @@ class SymphonyGeothermal(object):
         self.max_fails = max_fails
         self.fails = 0
         self._location_data = None
+        # Unique ID for the account, regardless of email changes.
+        self.account_id = None
         _LOGGER.debug(self)
 
     def __repr__(self):
@@ -202,6 +204,9 @@ class SymphonyGeothermal(object):
         recv = self.ws.recv()
         data = json.loads(recv)
         _LOGGER.debug("Login response: %s" % data)
+
+        if "key" in data:
+            self.account_id = data["key"]
 
         locations = data["locations"]
         self._location_data = locations


### PR DESCRIPTION
When logging in, store the unique "key"for the account so it can be used externally as a unique identifier even when the email changes.

This is useful for the HomeAssistant integration, and moving towards supporting multiple devices there. [Discussion](https://github.com/home-assistant/core/pull/162692#discussion_r2795567100)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/waterfurnace/16)
<!-- Reviewable:end -->
