### PR TITLE
Improve error handling on energy data

### DIFF
--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -487,6 +487,29 @@ class TestEnergyData(unittest.TestCase):
         with pytest.raises(wf.WFError):
             w.get_energy_data("2026-01-03", "2026-01-04")
 
+    @mock.patch("requests.get")
+    @mock.patch("websocket.create_connection")
+    @mock.patch("requests.post")
+    def test_get_energy_data_empty_response(self, mock_post, mock_ws_create, mock_get):
+        """Test get_energy_data raises WFNoDataError on empty response."""
+        # Setup login mocks
+        mock_post.return_value = FakeRequest(cookies={"sessionid": "test_session_id"})
+        m_ws = mock.MagicMock()
+        m_ws.recv.return_value = FAKE_CONTENT
+        mock_ws_create.return_value = m_ws
+
+        # Setup empty response (simulates out-of-bounds date range)
+        mock_response = mock.MagicMock()
+        mock_response.text = ""
+        mock_response.raise_for_status = mock.MagicMock()
+        mock_get.return_value = mock_response
+
+        w = wf.WaterFurnace("test@example.com", "password")
+        w.login()
+
+        with pytest.raises(wf.WFNoDataError):
+            w.get_energy_data("2026-01-03", "2026-01-04")
+
 
 class TestSymphonyLocationMethods:
     """Tests for locations and devices properties in SymphonyGeothermal."""

--- a/waterfurnace/cli.py
+++ b/waterfurnace/cli.py
@@ -202,6 +202,8 @@ def main(
                     click.echo("   Avg: {:.2f}".format(avg_val))
                     click.echo("   Total: {:.2f}".format(total_val))
 
+        except waterfurnace.waterfurnace.WFNoDataError as e:
+            click.echo(f"No data available: {e}")
         except Exception as e:
             click.echo("Error getting energy data: {}".format(e))
             raise

--- a/waterfurnace/waterfurnace.py
+++ b/waterfurnace/waterfurnace.py
@@ -107,6 +107,10 @@ class WFError(WFException):
     pass
 
 
+class WFNoDataError(WFException):
+    pass
+
+
 class SymphonyGeothermal(object):
     def __init__(
         self,
@@ -417,9 +421,15 @@ class SymphonyGeothermal(object):
                 timeout=TIMEOUT,
             )
             res.raise_for_status()
+            if not res.text.strip():
+                raise WFNoDataError(
+                    f"No energy data available for {start_date} to {end_date}"
+                )
             data = res.json()
             _LOGGER.debug(f"Received energy data: {len(data.get('index', []))} records")
             return WFEnergyData(data)
+        except WFNoDataError:
+            raise
         except requests.exceptions.HTTPError as e:
             _LOGGER.error(f"HTTP error getting energy data: {e}")
             raise WFError(f"Failed to get energy data: {e}")

--- a/waterfurnace/waterfurnace.py
+++ b/waterfurnace/waterfurnace.py
@@ -604,12 +604,14 @@ class WFEnergyReading(object):
 class WFEnergyData(object):
     """Container for energy data with multiple readings."""
 
-    def __init__(self, data={}):
+    def __init__(self, data=None):
         """Initialize energy data from API response.
 
         Args:
             data: Dictionary containing columns, index, and data arrays
         """
+        if data is None:
+            data = {}
         self.columns = data.get("columns", [])
         self.index = data.get("index", [])
         self.data = data.get("data", [])


### PR DESCRIPTION
While testing, I discovered that the current implementation it doesn't handle the scenario where data isn't available. When bulk fetching data (for back-filling energy data in HA) it would be great to have a specific error for this. Additionally I found a footgun using a dict in a default param.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/waterfurnace/17)
<!-- Reviewable:end -->
